### PR TITLE
Add user registration module

### DIFF
--- a/HacksterBot/.env.example
+++ b/HacksterBot/.env.example
@@ -200,6 +200,12 @@ BRIDGE_TIME_AI_SERVICE=gemini
 BRIDGE_TIME_AI_MODEL=gemini-2.0-flash
 
 # =====================================
+# User Module Configuration
+# =====================================
+USER_MODULE_ENABLED=true
+REGISTERED_ROLE_ID=0
+
+# =====================================
 # Development Settings
 # =====================================
 DEBUG=false

--- a/HacksterBot/core/bot.py
+++ b/HacksterBot/core/bot.py
@@ -157,6 +157,7 @@ class HacksterBot(commands.Bot):
             'meetings': self.config.meetings.enabled,  # Meeting scheduling system
             'recording': self.config.recording.enabled,  # Meeting recording system
             'bridge_time': self.config.bridge_time.enabled,  # Meeting time bridge
+            'users': self.config.user.enabled,
         }
         
         return module_config_map.get(module_name, True)

--- a/HacksterBot/core/config.py
+++ b/HacksterBot/core/config.py
@@ -239,6 +239,13 @@ class BridgeTimeConfig:
 
 
 @dataclass
+class UserModuleConfig:
+    """Configuration for the user registration module."""
+    enabled: bool = field(default_factory=lambda: os.getenv("USER_MODULE_ENABLED", "true").lower() == "true")
+    registered_role_id: int = field(default_factory=lambda: int(os.getenv("REGISTERED_ROLE_ID", "0")))
+
+
+@dataclass
 class LoggingConfig:
     """Logging configuration."""
     level: str = "INFO"
@@ -263,6 +270,7 @@ class Config:
     recording: RecordingConfig = field(default_factory=RecordingConfig)
     meetings: MeetingsConfig = field(default_factory=MeetingsConfig)
     bridge_time: BridgeTimeConfig = field(default_factory=BridgeTimeConfig)
+    user: UserModuleConfig = field(default_factory=UserModuleConfig)
     logging: LoggingConfig = field(default_factory=LoggingConfig)
     
     # General settings
@@ -324,6 +332,7 @@ def load_config() -> Config:
         recording=RecordingConfig(),
         meetings=MeetingsConfig(),
         bridge_time=BridgeTimeConfig(),
+        user=UserModuleConfig(),
         logging=LoggingConfig(),
         
         debug=os.getenv("DEBUG", "false").lower() == "true",

--- a/HacksterBot/core/models.py
+++ b/HacksterBot/core/models.py
@@ -564,3 +564,26 @@ class BridgeSession(Document):
             if resp.user_id == user_id:
                 return resp
         return None
+
+
+class RegisteredUser(Document):
+    """Model for storing user registration information."""
+
+    user_id = IntField(required=True)
+    guild_id = IntField(required=True)
+    real_name = StringField(required=True, max_length=100)
+    email = StringField(required=True, max_length=200)
+    source = StringField(max_length=200)
+    education_stage = StringField(max_length=50)
+    registered_at = DateTimeField(default=datetime.utcnow)
+
+    meta = {
+        'collection': 'registered_users',
+        'indexes': [
+            ('user_id', 'guild_id'),
+            'email',
+        ]
+    }
+
+    def __str__(self):
+        return f"RegisteredUser(user_id={self.user_id}, email={self.email})"

--- a/HacksterBot/modules/users/__init__.py
+++ b/HacksterBot/modules/users/__init__.py
@@ -1,0 +1,165 @@
+"""User registration module for HacksterBot."""
+
+import logging
+import re
+import discord
+from discord import app_commands
+from discord.ui import View, Button, Modal, TextInput, Select
+
+from core.module_base import ModuleBase
+from core.exceptions import ModuleError
+from core.models import RegisteredUser
+
+
+logger = logging.getLogger(__name__)
+
+
+class RegistrationStartView(View):
+    """Persistent view with a button to start registration."""
+
+    def __init__(self, module):
+        super().__init__(timeout=None)
+        self.module = module
+
+    @discord.ui.button(label="Hack Into It！", style=discord.ButtonStyle.primary, custom_id="start_registration")
+    async def start(self, interaction: discord.Interaction, button: Button):
+        modal = RegistrationModal(self.module)
+        await interaction.response.send_modal(modal)
+
+
+class RegistrationModal(Modal):
+    """Modal to collect basic user info."""
+
+    def __init__(self, module):
+        super().__init__(title="使用者資料")
+        self.module = module
+        self.name_input = TextInput(label="真實姓名", required=True)
+        self.email_input = TextInput(label="Email", required=True)
+        self.source_input = TextInput(label="從哪裡得知我們的 (選填)", required=False)
+        self.add_item(self.name_input)
+        self.add_item(self.email_input)
+        self.add_item(self.source_input)
+
+    async def on_submit(self, interaction: discord.Interaction):
+        name = self.name_input.value.strip()
+        email = self.email_input.value.strip()
+        source = self.source_input.value.strip()
+
+        if not re.match(r"^[^@\s]+@[^@\s]+\.[^@\s]+$", email):
+            await interaction.response.send_message("Email 格式錯誤，請重新輸入。", ephemeral=True)
+            return
+
+        view = EducationSelectView(self.module, name, email, source)
+        await interaction.response.send_message("請選擇您的教育階段：", view=view, ephemeral=True)
+
+
+class EducationSelect(discord.ui.Select):
+    """Select menu for education stage."""
+
+    def __init__(self, module, name: str, email: str, source: str):
+        options = [
+            discord.SelectOption(label="小學", value="小學"),
+            discord.SelectOption(label="國中", value="國中"),
+            discord.SelectOption(label="高中", value="高中"),
+            discord.SelectOption(label="大學以上", value="大學以上"),
+        ]
+        super().__init__(placeholder="選擇教育階段", options=options)
+        self.module = module
+        self.name = name
+        self.email = email
+        self.source = source
+
+    async def callback(self, interaction: discord.Interaction):
+        stage = self.values[0]
+        view = ConfirmView(self.module, self.name, self.email, self.source, stage)
+        embed = discord.Embed(title="歡迎來到 HackIt！", description="babababa")
+        await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
+
+
+class EducationSelectView(View):
+    def __init__(self, module, name: str, email: str, source: str):
+        super().__init__(timeout=180)
+        self.add_item(EducationSelect(module, name, email, source))
+
+
+class ConfirmView(View):
+    """Final confirmation view."""
+
+    def __init__(self, module, name: str, email: str, source: str, stage: str):
+        super().__init__(timeout=180)
+        self.module = module
+        self.name = name
+        self.email = email
+        self.source = source
+        self.stage = stage
+
+    @discord.ui.button(label="我已閱讀上述規範，我是乖寶寶，我會遵守！", style=discord.ButtonStyle.success, custom_id="agree_rules")
+    async def confirm(self, interaction: discord.Interaction, button: Button):
+        role_id = self.module.config.user.registered_role_id
+        if role_id:
+            role = interaction.guild.get_role(role_id)
+            if role:
+                try:
+                    await interaction.user.add_roles(role, reason="User registration")
+                except Exception as e:
+                    logger.error(f"Failed to add role: {e}")
+
+        try:
+            RegisteredUser.objects(
+                user_id=interaction.user.id,
+                guild_id=interaction.guild.id
+            ).update_one(
+                set__real_name=self.name,
+                set__email=self.email,
+                set__source=self.source,
+                set__education_stage=self.stage,
+                set_on_insert__registered_at=discord.utils.utcnow(),
+                upsert=True,
+            )
+        except Exception as e:
+            logger.error(f"Failed to save registration info: {e}")
+
+        await interaction.response.send_message("註冊完成，感謝你的加入！", ephemeral=True)
+
+
+class UsersModule(ModuleBase):
+    """User registration workflow module."""
+
+    def __init__(self, bot, config):
+        super().__init__(bot, config)
+        self.name = "users"
+        self.description = "User registration and role assignment"
+
+    async def setup(self):
+        try:
+            if not self.config.user.enabled:
+                logger.info("User module is disabled")
+                return
+
+            self.bot.add_view(RegistrationStartView(self))
+
+            @self.bot.tree.command(name="registration_panel", description="發送註冊面板 (管理員)")
+            @app_commands.checks.has_permissions(administrator=True)
+            async def registration_panel(interaction: discord.Interaction):
+                view = RegistrationStartView(self)
+                embed = discord.Embed(title="Hack Into It！")
+                await interaction.channel.send(embed=embed, view=view)
+                await interaction.response.send_message("已發送註冊面板", ephemeral=True)
+
+            logger.info("Users module setup completed")
+        except Exception as e:
+            logger.error(f"Failed to setup users module: {e}")
+            raise ModuleError(f"Users module setup failed: {e}")
+
+    async def teardown(self):
+        try:
+            self.bot.tree.remove_command("registration_panel")
+        except Exception:
+            pass
+        await super().teardown()
+
+
+async def setup(bot, config):
+    module = UsersModule(bot, config)
+    await module.setup()
+    bot.modules['users'] = module

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - **會議系統**：智慧會議安排與錄製管理
 - **邀請管理**：追蹤和管理伺服器邀請連結
 - **歡迎系統**：自動歡迎新成員
+- **用戶註冊**：表單收集並自動授予身份組
 - **遊戲功能**：內建 21 點等遊戲
 - **URL 安全檢查**：檢測惡意連結
 - **彈性配置**：透過環境變數輕鬆配置
@@ -36,6 +37,7 @@ HacksterBot/
 │   ├── moderation/                # 審核系統
 │   ├── tickets/                   # 票務系統
 │   ├── welcome/                   # 歡迎系統
+│   ├── users/                     # 用戶註冊
 │   └── url_safety/                # URL 安全檢查
 ├── config/                        # 配置文件
 │   ├── __init__.py
@@ -125,6 +127,11 @@ python main.py
 ### 歡迎模組 (`modules/welcome`)
 - **功能**：新成員歡迎、重試機制
 - **配置**：`WELCOME_ENABLED`, `WELCOME_CHANNEL_IDS`
+- **依賴**：無
+
+### 用戶模組 (`modules/users`)
+- **功能**：表單收集並授予身份組
+- **配置**：`USER_MODULE_ENABLED`, `REGISTERED_ROLE_ID`
 - **依賴**：無
 
 ### 會議模組 (`modules/meetings`)


### PR DESCRIPTION
## Summary
- implement a new `users` module to guide members through a registration flow
- store registration info in MongoDB and grant a role after confirmation
- introduce `RegisteredUser` document and configuration for the module
- update bot configuration and module loading logic
- document new module and settings in README and `.env.example`

## Testing
- `python -m py_compile HacksterBot/modules/users/__init__.py HacksterBot/core/models.py HacksterBot/core/config.py HacksterBot/core/bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6842f062862883299b8750fac1b07fd5